### PR TITLE
Minor CLI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,9 @@ inc/
 .last_cover_stats
 nytprof.out
 pod2htm*.tmp
+pm_to_blib
 module-starter-*
 module-starter-*.tar.gz
+t/data/MyModule-Test/*
+t/data/Book-Park-Mansfield/*
+t/data/loop/*

--- a/bin/module-starter
+++ b/bin/module-starter
@@ -34,8 +34,8 @@ Options:
     --ignores=type   Ignore type files to include (repeatable)
     --license=type   License under which the module will be distributed
                      (default is the same license as perl)
-     --minperl=ver    Minimum Perl version required (optional;
-                      default is 5.006)
+    --minperl=ver    Minimum Perl version required (optional;
+                     default is 5.006)
 
     --verbose        Print progress messages while working
     --force          Delete pre-existing files if needed
@@ -43,13 +43,15 @@ Options:
     --help           Show this message
 
 Available Licenses:
+
     perl, artistic, artistic2, mit, mozilla, mozilla2, bsd, freebsd, cc0,
-     gpl, lgpl, gpl3, lgpl3, agpl3, apache, qpl
+    gpl, lgpl, gpl3, lgpl3, agpl3, apache, qpl
      
 Available Ignore Types:
+
     cvs, git, manifest, generic
-     (NOTE: If manifest is included, the MANIFEST file will be skipped
-     and only a MANIFEST.SKIP file will be included.)
+    (NOTE: If manifest is included, the MANIFEST file will be skipped
+    and only a MANIFEST.SKIP file will be included.)
      
 Example:
 

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -1452,6 +1452,7 @@ inc/
 .last_cover_stats
 nytprof.out
 pod2htm*.tmp
+pm_to_blib
 $self->{distro}-*
 $self->{distro}-*.tar.gz
 EOF

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -846,6 +846,7 @@ inc/
 .last_cover_stats
 nytprof.out
 pod2htm*.tmp
+pm_to_blib
 $distro-*
 $distro-*.tar.gz
 EOF


### PR DESCRIPTION
Found some minor problems with the CLI, some of which had to do with my changes, though others were already there.  (For example, I'm not sure how the example command line in module-starter --help even worked, since comma-separated module lists wouldn't have worked as expected...)

```
Fix CLI to work with comma-separated lists properly
Fix minor whitespace issues to CLI docs
Add pm_to_blib to .gitignore (both here and others)
Add t/data/[test folders] to .gitignore (just ours)
```
