### PR TITLE
Fix address of FSF in template blocks and tests

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -480,7 +480,7 @@ GNU General Public License for more details.
 
 A copy of the GNU General Public License is available in the source tree;
 if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 EOT
     },
     lgpl => {
@@ -500,8 +500,8 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this program; if not, write to the Free
-Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-02111-1307 USA.
+Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 EOT
     },
     gpl3 => {

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -359,7 +359,7 @@ GNU General Public License for more details.
 
 A copy of the GNU General Public License is available in the source tree;
 if not, write to the Free Software Foundation, Inc.,
-59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 EOT
     },
     lgpl => {
@@ -379,8 +379,8 @@ Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public
 License along with this program; if not, write to the Free
-Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-02111-1307 USA.
+Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 EOT
     },
     gpl3 => {


### PR DESCRIPTION
The FSF's physical mailing address changed about 2 years ago I think.  All of the template blocks with the FSF's mailing address have been updated, as well as the tests that test for those template blocks.
