### PR TITLE
Update Simple.pm

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -93,7 +93,7 @@ sub create_distro {
         croak "Invalid module name: $_" unless /\A[a-z_]\w*(?:::[\w]+)*\Z/i;
     }
 
-    if ( not $self->{author} ) {
+    if ( ( not $self->{author} ) && ( $^O ne 'MSWin32' ) ) {
         ( $self->{author} ) = split /,/, ( getpwuid $> )[6];
     }
 


### PR DESCRIPTION
A patch to stop getpwuid calls for Windows where the value of Author has not been specified by the user. In such cases users won't get the that getpwuid is unimplemented on their platform, but they will be told to provide a value for Author.

rt: https://rt.cpan.org/Ticket/Display.html?id=85600
