### PR TITLE
Edit license slnames to match CPAN::Meta::Spec

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -354,7 +354,7 @@ EOT
     },
     mozilla2 => {
         license => 'mozilla2',
-        slname  => 'Mozilla_2_0',
+        slname  => 'open_source',
         url     => 'http://www.mozilla.org/MPL/2.0/',
         blurb   => <<'EOT',
 This Source Code Form is subject to the terms of the Mozilla Public
@@ -433,7 +433,7 @@ EOT
     },
     cc0 => {
         license => 'cc0',
-        slname  => 'CC0',
+        slname  => 'unrestricted',
         url     => 'http://creativecommons.org/publicdomain/zero/1.0/',
         blurb   => <<'EOT',
 This program is distributed under the CC0 1.0 Universal License:

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -233,7 +233,7 @@ EOT
     },
     mozilla2 => {
         license => 'mozilla2',
-        slname  => 'Mozilla_2_0',
+        slname  => 'open_source',
         url     => 'http://www.mozilla.org/MPL/2.0/',
         blurb   => <<'EOT',
 This Source Code Form is subject to the terms of the Mozilla Public
@@ -312,7 +312,7 @@ EOT
     },
     cc0 => {
         license => 'cc0',
-        slname  => 'CC0',
+        slname  => 'unrestricted',
         url     => 'http://creativecommons.org/publicdomain/zero/1.0/',
         blurb   => <<'EOT',
 This program is distributed under the CC0 1.0 Universal License:


### PR DESCRIPTION
CPAN::Meta::Spec is very restrictive about license names, including being case sensitive. A lot of the names in here will result in an "Unknown" license type in the META file. This PR brings these names in-line with the CPAN::Meta::Spec list in case sensitivity and version numbering.

Additionally, Mozilla 2.0 and CC0 are not recognized by the meta licensing yet. As such, they have been entered as open_source and unrestricted, respectively.
