### PR TITLE
document how to use ignore file types in configuration

### DIFF
--- a/bin/module-starter
+++ b/bin/module-starter
@@ -80,12 +80,14 @@ line parameters.  The default location is C<$HOME/.module-starter/config> but
 if the MODULE_STARTER_DIR environment variable is set, module-starter will look
 for C<config> in that directory.
 
-The configuration file is just a list of names and values, separated by colons.
-Values that take lists are just space separated.  A sample configuration file
-might read:
+The configuration file is just a list of names and values, separated by
+colons.  Values that take lists are just space separated. Note that the
+C<--ignores> command line parameter corresponds to the C<ignores_type>
+configuration file entry. A sample configuration file might read:
 
  author: Ricardo SIGNES
  email:  rjbs@cpan.org
+ ignores_type: git
  plugins: Module::Starter::Simple Module::Starter::Plugin::XYZ
  xyz_option: red green blue
 


### PR DESCRIPTION
I think that ideally the command-line parameter and the config file parameter for the type of ignore file to create should be the same, or at least there should be some spelling that's accepted for both, but perhaps there's a reason I haven't seen for this not being the case.

This commit just changes the documentation for the command-line tool to mention the difference and include an example of how to specify an ignore file type in the configuration, and thereby fixes issue https://github.com/xsawyerx/module-starter/issues/17 (which I found when googling for the problem I had). If you'd rather I fix it by changing the code to accept one or both of the spellings in both places, I'll do that instead.
