### PR TITLE
Fix documentation to match code: default license is artistic2

### DIFF
--- a/bin/module-starter
+++ b/bin/module-starter
@@ -33,7 +33,7 @@ Options:
 
     --ignores=type   Ignore type files to include (repeatable)
     --license=type   License under which the module will be distributed
-                     (default is the same license as perl)
+                     (default is artistic2)
     --minperl=ver    Minimum Perl version required (optional;
                      default is 5.006)
 


### PR DESCRIPTION
This seems to have been accidentally broken in 6e312fde06d46928ecbb173df47f2dd06847c905 when adjacent changes were being made.
