### PR TITLE
Update bugtracker URL to GitHub (From rt.cpan.org) Fixes issue #20

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for Perl extension Module::Starter
 
 1.63	??? Jan 2015
-        (Add changes here)
+        * Change the url for issues from rt.cpan.org to GitHub (David Pottage)
 
 1.62    Sun Dec  8 11:49:21 2013
         * Fix regexp in tests to stop failing on 5.8.x (Sawyer X).

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Module::Starter
 
+1.63	??? Jan 2015
+        (Add changes here)
+
 1.62    Sun Dec  8 11:49:21 2013
         * Fix regexp in tests to stop failing on 5.8.x (Sawyer X).
         * Fix FSF address in template block and tests (Brian Manning).

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ WriteMakefile(
             resources => {
                 homepage   => 'https://github.com/xsawyerx/module-starter',
                 repository => 'https://github.com/xsawyerx/module-starter.git',
-                bugtracker => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=Module-Starter',
+                bugtracker => 'https://github.com/xsawyerx/module-starter/issues',
             },
         })
     ),

--- a/lib/Module/Starter.pm
+++ b/lib/Module/Starter.pm
@@ -10,11 +10,11 @@ Module::Starter - a simple starter kit for any module
 
 =head1 VERSION
 
-Version 1.62
+Version 1.63
 
 =cut
 
-our $VERSION = '1.62';
+our $VERSION = '1.63';
 
 =head1 SYNOPSIS
 

--- a/lib/Module/Starter.pm
+++ b/lib/Module/Starter.pm
@@ -144,7 +144,7 @@ L<http://cpanratings.perl.org/d/Module-Starter>
 
 =item * RT: CPAN's request tracker
 
-L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=Module-Starter>
+L<https://github.com/xsawyerx/module-starter/issuesr>
 
 =item * Search CPAN
 
@@ -154,10 +154,10 @@ L<http://search.cpan.org/dist/Module-Starter>
 
 =head1 BUGS
 
-Please report any bugs or feature requests to
-C<bug-module-starter at rt.cpan.org>, or through the web interface at
-L<http://rt.cpan.org>.  I will be notified, and then you'll automatically be
-notified of progress on your bug as I make changes.
+Please report any bugs or feature requests to the bugtracker for this project
+on GitHub at: L<https://github.com/xsawyerx/module-starter/issues>. I will be
+notified, and then you'll automatically be notified of progress on your bug
+as I make changes.
 
 =head1 COPYRIGHT
 

--- a/lib/Module/Starter/App.pm
+++ b/lib/Module/Starter/App.pm
@@ -9,7 +9,7 @@ Module::Starter::App - the code behind the command line program
 use warnings;
 use strict;
 
-our $VERSION = '1.62';
+our $VERSION = '1.63';
 
 use Path::Class;
 use Getopt::Long;

--- a/lib/Module/Starter/BuilderSet.pm
+++ b/lib/Module/Starter/BuilderSet.pm
@@ -11,11 +11,11 @@ Module::Starter::BuilderSet - determine builder metadata
 
 =head1 VERSION
 
-Version 1.62
+Version 1.63
 
 =cut
 
-our $VERSION = '1.62';
+our $VERSION = '1.63';
 
 =head1 SYNOPSIS
 

--- a/lib/Module/Starter/BuilderSet.pm
+++ b/lib/Module/Starter/BuilderSet.pm
@@ -272,10 +272,10 @@ sub default_builder {
 
 =head1 BUGS
 
-Please report any bugs or feature requests to
-C<bug-module-starter at rt.cpan.org>, or through the web interface at
-L<http://rt.cpan.org>.  I will be notified, and then you'll automatically
-be notified of progress on your bug as I make changes.
+Please report any bugs or feature requests to the bugtracker for this project
+on GitHub at: L<https://github.com/xsawyerx/module-starter/issues>. I will be
+notified, and then you'll automatically be notified of progress on your bug
+as I make changes.
 
 =head1 AUTHOR
 

--- a/lib/Module/Starter/Plugin/Template.pm
+++ b/lib/Module/Starter/Plugin/Template.pm
@@ -10,11 +10,11 @@ Module::Starter::Plugin::Template - module starter with templates
 
 =head1 VERSION
 
-Version 1.62
+Version 1.63
 
 =cut
 
-our $VERSION = '1.62';
+our $VERSION = '1.63';
 
 =head1 SYNOPSIS
 

--- a/lib/Module/Starter/Plugin/Template.pm
+++ b/lib/Module/Starter/Plugin/Template.pm
@@ -236,10 +236,10 @@ Ricardo SIGNES, C<< <rjbs at cpan.org> >>
 
 =head1 Bugs
 
-Please report any bugs or feature requests to
-C<bug-module-starter at rt.cpan.org>, or through the web interface at
-L<http://rt.cpan.org>.  I will be notified, and then you'll automatically be
-notified of progress on your bug as I make changes.
+Please report any bugs or feature requests to the bugtracker for this project
+on GitHub at: L<https://github.com/xsawyerx/module-starter/issues>. I will be
+notified, and then you'll automatically be notified of progress on your bug
+as I make changes.
 
 =head1 COPYRIGHT
 

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -17,11 +17,11 @@ Module::Starter::Simple - a simple, comprehensive Module::Starter plugin
 
 =head1 VERSION
 
-Version 1.62
+Version 1.63
 
 =cut
 
-our $VERSION = '1.62';
+our $VERSION = '1.63';
 
 =head1 SYNOPSIS
 

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -1583,10 +1583,10 @@ sub filter_lines_in_file {
 
 =head1 BUGS
 
-Please report any bugs or feature requests to
-C<bug-module-starter at rt.cpan.org>, or through the web interface at
-L<http://rt.cpan.org>.  I will be notified, and then you'll automatically
-be notified of progress on your bug as I make changes.
+Please report any bugs or feature requests to the bugtracker for this project
+on GitHub at: L<https://github.com/xsawyerx/module-starter/issues>. I will be
+notified, and then you'll automatically be notified of progress on your bug
+as I make changes.
 
 =head1 AUTHOR
 

--- a/t/data/templates/Module.pm
+++ b/t/data/templates/Module.pm
@@ -54,12 +54,10 @@ C.J. Adams-Collier, C<< <cjac at colliertech.org> >>
 
 =head1 BUGS
 
-Please report any bugs or feature requests to C<bug-foo-bar at rt.cpan.org>, or through
-the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Foo-Bar>.  I will be notified, and then you'll
-automatically be notified of progress on your bug as I make changes.
-
-
-
+Please report any bugs or feature requests to the bugtracker for this project
+on GitHub at: L<https://github.com/xsawyerx/module-starter/issues>. I will be
+notified, and then you'll automatically be notified of progress on your bug
+as I make changes.
 
 =head1 SUPPORT
 

--- a/t/data/templates/README
+++ b/t/data/templates/README
@@ -27,8 +27,8 @@ perldoc command.
 
 You can also look for information at:
 
-    RT, CPAN's request tracker
-        http://rt.cpan.org/NoAuth/Bugs.html?Dist=Foo-Bar
+    GitHub issue tracker
+        https://github.com/xsawyerx/module-starter/issues
 
     AnnoCPAN, Annotated CPAN documentation
         http://annocpan.org/dist/Foo-Bar


### PR DESCRIPTION
Change the bugtracker URL to GitHub, fixing issue #20.

We need to import existing issues on rt.cpan.org into GitHub using Lee's script:

https://github.com/leejo/rt-to-github

Then if possible close the issue tracker on rt.cpan.org so that no new issues are created there.