### PR TITLE
Add a command line option to make warnings fatal (Default off)

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ Revision history for Perl extension Module::Starter
         * Change the url for issues from rt.cpan.org to GitHub (David Pottage)
         * Added a missing module to prerequisites (David Pottage)
         * Marked t/pod* test scripts as RELEASE_TESTING (David Pottage)
+        * Added a --fatalize option to generate code where warnings are fatal
+          This changes the default behaviour, as fatal warnings are now considered
+          unwise for any public module that many others depend on.
+          See: http://blogs.perl.org/users/peter_rabbitson/2014/01/fatal-warnings-are-a-ticking-time-bomb-via-chromatic.html
 
 1.62    Sun Dec  8 11:49:21 2013
         * Fix regexp in tests to stop failing on 5.8.x (Sawyer X).

--- a/bin/module-starter
+++ b/bin/module-starter
@@ -39,7 +39,6 @@ Options:
 
     --fatalize       Generate code that causes all warnings to be fatal with:
                      use warnings FATAL => 'all'
-                     This is not recommended if your module has dependencies
 
     --verbose        Print progress messages while working
     --force          Delete pre-existing files if needed

--- a/bin/module-starter
+++ b/bin/module-starter
@@ -37,6 +37,10 @@ Options:
     --minperl=ver    Minimum Perl version required (optional;
                      default is 5.006)
 
+    --fatalize       Generate code that causes all warnings to be fatal with:
+                     use warnings FATAL => 'all'
+                     This is not recommended if your module has dependencies
+
     --verbose        Print progress messages while working
     --force          Delete pre-existing files if needed
 

--- a/lib/Module/Starter.pm
+++ b/lib/Module/Starter.pm
@@ -57,7 +57,7 @@ It takes a hash of params, as follows:
     author       => $author,   # author's full name (taken from C<getpwuid> if not provided)
     email        => $email,    # author's email address (taken from C<EMAIL> if not provided)
     ignores_type => $type,     # ignores file type ('generic', 'cvs', 'git', 'hg', 'manifest' )
-    fatalize     => $fatalize, # Generate code that makes warnings fatal. (Not recommended)
+    fatalize     => $fatalize, # Generate code that makes warnings fatal.
 
     verbose      => $verbose,  # bool: print progress messages; defaults to 0
     force        => $force     # bool: overwrite existing files; defaults to 0

--- a/lib/Module/Starter.pm
+++ b/lib/Module/Starter.pm
@@ -57,6 +57,7 @@ It takes a hash of params, as follows:
     author       => $author,   # author's full name (taken from C<getpwuid> if not provided)
     email        => $email,    # author's email address (taken from C<EMAIL> if not provided)
     ignores_type => $type,     # ignores file type ('generic', 'cvs', 'git', 'hg', 'manifest' )
+    fatalize     => $fatalize, # Generate code that makes warnings fatal. (Not recommended)
 
     verbose      => $verbose,  # bool: print progress messages; defaults to 0
     force        => $force     # bool: overwrite existing files; defaults to 0

--- a/lib/Module/Starter/App.pm
+++ b/lib/Module/Starter/App.pm
@@ -82,6 +82,8 @@ sub _process_command_line {
         'email=s'    => \$config{email},
         'license=s'  => \$config{license},
         'minperl=s'  => \$config{minperl},
+        'fatalize'   => \$config{fatalize},
+
         force        => \$config{force},
         verbose      => \$config{verbose},
         version      => sub {

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -753,10 +753,12 @@ sub Makefile_PL_guts {
     
     my $slname = $self->{license_record} ? $self->{license_record}->{slname} : $self->{license};
 
+    my $warnings = sprintf 'warnings%s;', ($self->{fatalize} ? " FATAL => 'all" : '');
+
     return <<"HERE";
 use $self->{minperl};
 use strict;
-use warnings FATAL => 'all';
+use $warnings
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
@@ -802,10 +804,12 @@ sub MI_Makefile_PL_guts {
     
     my $license_url = $self->{license_record} ? $self->{license_record}->{url} : '';
 
+    my $warnings = sprintf 'warnings%s;', ($self->{fatalize} ? " FATAL => 'all" : '');
+
     return <<"HERE";
 use $self->{minperl};
 use strict;
-use warnings FATAL => 'all';
+use $warnings
 use inc::Module::Install;
 
 name     '$self->{distro}';
@@ -891,10 +895,12 @@ sub Build_PL_guts {
 
     my $slname = $self->{license_record} ? $self->{license_record}->{slname} : $self->{license};
     
+    my $warnings = sprintf 'warnings%s;', ($self->{fatalize} ? " FATAL => 'all" : '');
+
     return <<"HERE";
 use $self->{minperl};
 use strict;
-use warnings FATAL => 'all';
+use $warnings
 use Module::Build;
 
 my \$builder = Module::Build->new(
@@ -1097,11 +1103,13 @@ sub t_guts {
 
     my %t_files;
     my $minperl = $self->{minperl};
+    my $warnings = sprintf 'warnings%s;', ($self->{fatalize} ? " FATAL => 'all" : '');
+
     my $header = <<"EOH";
 #!perl -T
 use $minperl;
 use strict;
-use warnings FATAL => 'all';
+use $warnings
 use Test::More;
 
 EOH
@@ -1622,12 +1630,14 @@ sub _module_header {
     my $self = shift;
     my $module = shift;
     my $rtname = shift;
+    my $warnings = sprintf 'warnings%s;', ($self->{fatalize} ? " FATAL => 'all" : '');
+
     my $content = <<"HERE";
 package $module;
 
 use $self->{minperl};
 use strict;
-use warnings FATAL => 'all';
+use $warnings
 
 \=head1 NAME
 

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -557,7 +557,7 @@ sub parse_file_start {
         Carp::confess( "Wrong method for testing $basefn; use TestParseModuleFile" );
     }
     
-    my $msw_re  = qr{use \Q$minperl;\E\n\Quse strict;\E\n\Quse warnings FATAL => 'all';\E\n};
+    my $msw_re  = qr{use \Q$minperl;\E\n\Quse strict;\E\n\Quse warnings;\E\n};
     my $mswb_re = $self->{builder} eq 'Module::Install' ? qr{\A$msw_re\Quse inc::$self->{builder};\E\n\n} : qr{\A$msw_re\Quse $self->{builder};\E\n\n};
     my $mswt_re = qr{\A\Q#!perl -T\E\n$msw_re\Quse Test::More;\E\n\n};
     
@@ -1053,7 +1053,7 @@ sub parse_module_start {
     Test::More::plan tests => 19;
 
     $self->parse(
-        qr/\Apackage \Q$perl_name\E;\n\nuse $minperl;\nuse strict;\n\Quse warnings FATAL => 'all';\E\n\n/ms,
+        qr/\Apackage \Q$perl_name\E;\n\nuse $minperl;\nuse strict;\n\Quse warnings;\E\n\n/ms,
         'start',
     );
 


### PR DESCRIPTION
Fixes issue #40 (bug #93023 on RT)

Unit test updated to not expect warnings to be fatal. POD docs updated.