### PR TITLE
avoid the use of Module::Build::Compat in Build.PL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ module-starter-*.tar.gz
 t/data/MyModule-Test/*
 t/data/Book-Park-Mansfield/*
 t/data/loop/*
+/_eumm/

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Module::Starter
 
+        * GH#51: drop use of Module::Build::Compat in Build.PL (Karen
+          Etheridge)
+
 1.71    Fri Jan 30 13:28:31 2015
         * GH #47: create_t breaks plugins. (David Pottage)
 

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -920,7 +920,6 @@ my \$builder = Module::Build->new(
         #'Foo::Bar::Module' => 5.0401,
     },
     add_to_cleanup     => [ '$self->{distro}-*' ],
-    create_makefile_pl => 'traditional',
 );
 
 \$builder->create_build_script();

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -593,7 +593,7 @@ sub parse_file_start {
         );
     }
     elsif ($basefn eq 'Build.PL' && $self->{builder} eq 'Module::Build') {
-        plan tests => 11;
+        plan tests => 10;
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
         );
@@ -636,11 +636,6 @@ sub parse_file_start {
         $self->parse(
             qr/\A\s*add_to_cleanup *=> \Q[ '$distro-*' ],\E\n/ms,
             "add_to_cleanup",
-        );
-
-        $self->parse(
-            qr/\A\s*create_makefile_pl *=> \Q'traditional',\E\n/ms,
-            "create_makefile_pl",
         );
     }
     elsif ($basefn eq 'Makefile.PL' && $self->{builder} eq 'ExtUtils::MakeMaker') {


### PR DESCRIPTION
If ExtUtils::MakeMaker can be used to build the distribution identically, it
is much preferable for the author to simply use EUMM rather than
Module::Build.  Users should not be using this mode without careful
consideration.
