### PR TITLE
Add support for multiple authors to Module::Starter; Issue #25

### DIFF
--- a/bin/module-starter
+++ b/bin/module-starter
@@ -29,7 +29,10 @@ Options:
     --mi             Same as --builder=Module::Install
 
     --author=name    Author's name (taken from getpwuid if not provided)
-    --email=email    Author's email (taken from EMAIL if not provided)
+                     and Email address ( taken from $ENV{EMAIL} if Author's name is not provided )
+                     Format: Author Name <author_email@domain.tld>
+                     This option can be supplied multiple times for projects 
+                     that have multiple authors.
 
     --ignores=type   Ignore type files to include (repeatable)
     --license=type   License under which the module will be distributed
@@ -60,6 +63,10 @@ Example:
 
     module-starter --module=Foo::Bar,Foo::Bat \
         --author="Andy Lester" --email=andy@petdance.com
+
+    module-starter --module=Foo::Bar,Foo::Bat \
+        --author="Andy Lester <andy@petdance.com> \
+        --author="Sawyer X <sawyerx@cpan.org>
 
 =head1 DESCRIPTION
 
@@ -96,6 +103,9 @@ configuration file entry. A sample configuration file might read:
 
 This format may become more elaborate in the future, but a file of this type
 should remain valid.
+
+Please note, as of right now the configuration file does *not* have support 
+for multiple authors.
 
 =cut
 

--- a/lib/Module/Starter/App.pm
+++ b/lib/Module/Starter/App.pm
@@ -78,8 +78,7 @@ sub _process_command_line {
         mb           => sub { push @{$config{builder}}, 'Module::Build' },
         mi           => sub { push @{$config{builder}}, 'Module::Install' },
 
-        'author=s'   => \$config{author},
-        'email=s'    => \$config{email},
+        'author=s@' => \@{ $config{author} },
         'license=s'  => \$config{license},
         'minperl=s'  => \$config{minperl},
         'fatalize'   => \$config{fatalize},

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -506,7 +506,6 @@ sub parse_paras {
     local $Test::Builder::Level = $Test::Builder::Level + 1;
 
     my ($self, $paras, $msg) = @_;
-
     # Construct a large regex.
     my $regex =
         join '',
@@ -545,8 +544,7 @@ sub parse_file_start {
     
     my $slname      = $LICENSES->{ $self->{license} }->{slname};
     my $license_url = $LICENSES->{ $self->{license} }->{url};
-    
-    (my $authoremail = "$self->{author} <$self->{email}>") =~ s/'/\'/g;
+        
     (my $libmod = "lib/$mainmod".'.pm') =~ s|::|/|g;
     
     my $install_pl = $self->{builder} eq 'Module::Build' ? 'Build.PL' : 'Makefile.PL';
@@ -594,6 +592,9 @@ sub parse_file_start {
     }
     elsif ($basefn eq 'Build.PL' && $self->{builder} eq 'Module::Build') {
         plan tests => 11;
+        my $authoremail = join ',', map { "'$_'" } @{$self->{author}};
+        $authoremail =~ s/'/\'/g;
+        
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
         );
@@ -606,7 +607,7 @@ sub parse_file_start {
             "license",
         );
 
-        $self->parse(qr{\A\s*dist_author *=> *\Qq{$authoremail},\E\n}ms,
+        $self->parse(qr{\A\s*dist_author *=> *\Q[$authoremail],\E\n}ms,
             "dist_author",
         );
 
@@ -645,6 +646,9 @@ sub parse_file_start {
     }
     elsif ($basefn eq 'Makefile.PL' && $self->{builder} eq 'ExtUtils::MakeMaker') {
         plan tests => 11;
+        my $authoremail = join ',', map { "'$_'" } @{$self->{author}};
+        $authoremail =~ s/'/\'/g;
+        
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
         );
@@ -653,7 +657,7 @@ sub parse_file_start {
             "NAME",
         );
 
-        $self->parse(qr{\A\s*AUTHOR *=> *\Qq{$authoremail},\E\n}ms,
+        $self->parse(qr{\A\s*AUTHOR *=> *\Q[$authoremail],\E\n}ms,
             "AUTHOR",
         );
 
@@ -693,7 +697,12 @@ sub parse_file_start {
         );
     }
     elsif ($basefn eq 'Makefile.PL' && $self->{builder} eq 'Module::Install') {
-        plan tests => 13;
+       plan tests => 13;
+       # do not quote authoremail combinations for Module::Install since
+       # author is a string not an arrayref
+       my $authoremail = join ',', @{$self->{author}};
+       $authoremail =~ s/'/\'/g;
+       
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
         );
@@ -722,13 +731,15 @@ sub parse_file_start {
             "tests_recursive",
         );
         
+        my $repo_author = $self->{author}->[0];
+        ($repo_author) = (split /\s*\</, $repo_author)[0];
         $self->consume(<<"EOT", 'resources');
 resources (
    #homepage   => 'http://yourwebsitehere.com',
    #IRC        => 'irc://irc.perl.org/#$distro',
    license    => '$license_url',
-   #repository => 'git://github.com/$self->{author}/$distro.git',
-   #repository => 'https://bitbucket.org/$self->{author}/$self->{distro}',
+   #repository => 'git://github.com/$repo_author/$distro.git',
+   #repository => 'https://bitbucket.org/$repo_author/$self->{distro}',
    bugtracker => 'http://rt.cpan.org/NoAuth/Bugs.html?Dist=$distro',
 );
 
@@ -1046,7 +1057,7 @@ sub parse_module_start {
 
     my $perl_name    = $self->{module};
     my $dist_name    = $self->{distro};
-    my $author_name  = $self->{author};
+    my $author_name  = join ',', @{$self->{author}};
     my $lc_dist_name = lc($dist_name);
     my $minperl      = $self->{minperl} || 5.006;
     
@@ -1121,7 +1132,7 @@ sub parse_module_start {
     $self->parse_paras(
         [
             "=head1 AUTHOR",
-            { re => quotemeta($author_name) . q{[^\n]+} },
+            { re => quotemeta($author_name) },
         ],
         "AUTHOR",
     );
@@ -1239,6 +1250,7 @@ srand($random_seed);
 
 sub run_settest {
     my ($base_dir, $distro_var) = @_;
+
     my $module_base_dir = File::Spec->catdir(qw(t data), ref $base_dir ? @$base_dir : $base_dir);
     $distro_var->{dir} = $module_base_dir;
 
@@ -1345,8 +1357,10 @@ run_settest('MyModule-Test', {
     modules => ['MyModule::Test', 'MyModule::Test::App'],
     builder => 'Module::Build',
     license => 'artistic2',
-    author  => 'Baruch Spinoza',
-    email   => 'spinoza@philosophers.tld',
+    author  => [ 
+       'Baruch Spinoza <spinoza@philosophers.tld>', 
+       'Sandra OConnor <sdoc@philosphers.tld>' 
+    ],
     verbose => 0,
     force   => $DONT_DEL,    
 });
@@ -1361,8 +1375,7 @@ run_settest('Book-Park-Mansfield', {
     ],
     builder => 'Module::Build',
     license => 'artistic2',
-    author  => 'Jane Austen',
-    email   => 'jane.austen@writers.tld',
+    author  => [ 'Jane Austen <jane.austen@writers.tld>' ],
     verbose => 0,
     force   => $DONT_DEL,
 });
@@ -1409,7 +1422,8 @@ subtest "builder = $builder" => sub {
                 my $distro = join('-', rstr_array);
                 my $author = rstr.' '.rstr;
                 my $email  = join('.', rstr_array).'@'.join('.', rstr_array).'.tld';
-
+                $author .= ' <$email>';
+                
                 my @modules;
                 my $len = int(rand(20)) + 1;
                 push(@modules, rstr_module ) for (1 .. $len);
@@ -1430,8 +1444,7 @@ subtest "builder = $builder" => sub {
                         modules => \@modules,
                         builder => $builder,
                         license => $license,
-                        author  => $author,
-                        email   => $email,
+                        author  => [ $author ],
                         minperl => $minperl,
                         verbose => 0,
                         force   => $force,


### PR DESCRIPTION
The included changes add support for multiple authors to Module::Starter and propogate to the chosen builder option. To do this, it seemed appropriate to remove the --email option and ask that users' specify both the author name and email as a single option, which most of the builders expect anyway:

    module-starter --module=Foo::Bar,Foo::Bat \
        --author="Andy Lester <andy@petdance.com> \
        --author="Sawyer X <sawyerx@cpan.org>

The attribute that previously held the author, `$self->{author}` now holds an arrayref of authoremails. Which are passed in turn to Module::Build and ExtUtils::MakeMaker as arrayrefs and to Module::Install as a string.

I tried to follow the existing conventions that were used within the module, but please let me know if I missed anything and/or there are other change you would like me to make.