### PR TITLE
use version.pm to compare versions correctly in test

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ WriteMakefile(
         'Pod::Usage'                   => '1.21',
         'parent'                       => '0',
         'Module::Install::AuthorTests' => '0',
+        'version'                      => '0',
     },
     (! eval { ExtUtils::MakeMaker->VERSION('6.46') } ? () :
         (META_ADD => {

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -9,6 +9,7 @@ use Module::Starter;
 use File::Spec;
 use File::Path;
 use Carp;
+use version;
 
 package TestParseFile;
 
@@ -1382,10 +1383,10 @@ subtest "builder = $builder" => sub {
     subtest "license = $license" => sub {
         plan tests => 5;
 
-        foreach my $minperl (5.006, 5.008001, v5.10.0, 'v5.10.1', $^V) {
+        foreach my $minperl (5.006, 5.008001, v5.10.0, 'v5.10.1', $]) {
         subtest "minperl = $minperl" => sub {
-            plan ($minperl > $^V ? 
-                (skip_all => $minperl.' is actually newer than Perl version ($^V)') : 
+            plan (version->parse($minperl) > version->parse($]) ? 
+                (skip_all => "$minperl is actually newer than Perl version ($])") : 
                 (tests => 16)
             );
 


### PR DESCRIPTION
Comparing v-strings and $^V with numeric comparison does not work before 5.10.0 since $^V itself was a v-string, not a version object. Instead parse all the versions into version objects for comparison and compare to $].