### PR TITLE
remove unused dependency Module::Install::AuthorTests

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,6 @@ WriteMakefile(
         'Getopt::Long'                 => '0',
         'Pod::Usage'                   => '1.21',
         'parent'                       => '0',
-        'Module::Install::AuthorTests' => '0',
         'version'                      => '0',
     },
     (! eval { ExtUtils::MakeMaker->VERSION('6.46') } ? () :


### PR DESCRIPTION
This Module::Install plugin adds the 'author_tests' function, however the string 'author_tests' is not found anywhere in the repository or git log.