### PR TITLE
replace Path::Class usage with File::Spec

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,6 @@ WriteMakefile(
         'Test::Harness'                => '0.21',
         'ExtUtils::Command'            => '0',
         'File::Spec'                   => '0',
-        'Path::Class'                  => '0',
         'Getopt::Long'                 => '0',
         'Pod::Usage'                   => '1.21',
         'parent'                       => '0',

--- a/lib/Module/Starter/App.pm
+++ b/lib/Module/Starter/App.pm
@@ -11,7 +11,7 @@ use strict;
 
 our $VERSION = '1.71';
 
-use Path::Class;
+use File::Spec;
 use Getopt::Long;
 use Pod::Usage;
 use Carp qw( croak );
@@ -21,10 +21,10 @@ sub _config_file {
     my $configdir = $ENV{'MODULE_STARTER_DIR'} || '';
 
     if ( !$configdir && $ENV{'HOME'} ) {
-        $configdir = dir( $ENV{'HOME'}, '.module-starter' );
+        $configdir = File::Spec->catdir( $ENV{'HOME'}, '.module-starter' );
     }
 
-    return file( $configdir, 'config' );
+    return File::Spec->catfile( $configdir, 'config' );
 }
 
 


### PR DESCRIPTION
The only use of Path::Class appears to be to construct file paths, which File::Spec can do perfectly well.