### PR TITLE
Link to metacpan instead of search.cpan.org in default template

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -675,7 +675,7 @@ sub _reference_links {
         link     => 'http://cpanratings.perl.org/d/%s',
       },
       { title    => 'Search CPAN',
-        link     => 'http://search.cpan.org/dist/%s/',
+        link     => 'https://metacpan.org/release/%s',
       },
     );
 }


### PR DESCRIPTION
We should link to the more modern CPAN search engine by default, as www.cpan.org itself does. Any objections?