### PR TITLE
default templates: use test_requires for test requirements, add EUMM compatibility boilerplate

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -761,18 +761,17 @@ use strict;
 use $warnings
 use ExtUtils::MakeMaker;
 
-WriteMakefile(
+my %WriteMakefileArgs = (
     NAME             => '$main_module',
     AUTHOR           => q{$author},
     VERSION_FROM     => '$main_pm_file',
     ABSTRACT_FROM    => '$main_pm_file',
     LICENSE          => '$slname',
-    PL_FILES         => {},
     MIN_PERL_VERSION => '$self->{minperl}',
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => '0',
     },
-    BUILD_REQUIRES => {
+    TEST_REQUIRES => {
         'Test::More' => '0',
     },
     PREREQ_PM => {
@@ -782,6 +781,26 @@ WriteMakefile(
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => '$self->{distro}-*' },
 );
+
+# Compatibility with old versions of ExtUtils::MakeMaker
+unless (eval { ExtUtils::MakeMaker->VERSION('6.64'); 1 }) {
+    my \$test_requires = delete \$WriteMakefileArgs{TEST_REQUIRES} || {};
+    \@{\$WriteMakefileArgs{PREREQ_PM}}{keys %\$test_requires} = values %\$test_requires;
+}
+
+unless (eval { ExtUtils::MakeMaker->VERSION('6.55_03'); 1 }) {
+    my \$build_requires = delete \$WriteMakefileArgs{BUILD_REQUIRES} || {};
+    \@{\$WriteMakefileArgs{PREREQ_PM}}{keys %\$build_requires} = values %\$build_requires;
+}
+
+delete \$WriteMakefileArgs{CONFIGURE_REQUIRES}
+    unless eval { ExtUtils::MakeMaker->VERSION('6.52'); 1 };
+delete \$WriteMakefileArgs{MIN_PERL_VERSION}
+    unless eval { ExtUtils::MakeMaker->VERSION('6.48'); 1 };
+delete \$WriteMakefileArgs{LICENSE}
+    unless eval { ExtUtils::MakeMaker->VERSION('6.31'); 1 };
+
+WriteMakefile(%WriteMakefileArgs);
 HERE
 
 }
@@ -834,7 +853,7 @@ configure_requires (
    'Module::Install' => '0',
 );
 
-build_requires (
+test_requires (
    'Test::More' => '0',
 );
 
@@ -902,6 +921,7 @@ use $self->{minperl};
 use strict;
 use $warnings
 use Module::Build;
+Module::Build->VERSION('0.4004');
 
 my \$builder = Module::Build->new(
     module_name         => '$main_module',
@@ -910,9 +930,9 @@ my \$builder = Module::Build->new(
     dist_version_from   => '$main_pm_file',
     release_status      => 'stable',
     configure_requires => {
-        'Module::Build' => '0',
+        'Module::Build' => '0.4004',
     },
-    build_requires => {
+    test_requires => {
         'Test::More' => '0',
     },
     requires => {

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -560,7 +560,7 @@ sub parse_file_start {
     }
     
     my $msw_re  = qr{use \Q$minperl;\E\n\Quse strict;\E\n\Quse warnings;\E\n};
-    my $mswb_re = $self->{builder} eq 'Module::Install' ? qr{\A$msw_re\Quse inc::$self->{builder};\E\n\n} : qr{\A$msw_re\Quse $self->{builder};\E\n\n};
+    my $mswb_re = $self->{builder} eq 'Module::Install' ? qr{\A$msw_re\Quse inc::$self->{builder};\E\n\n} : qr{\A$msw_re\Quse $self->{builder};\E\n};
     my $mswt_re = qr{\A\Q#!perl -T\E\n$msw_re\Quse Test::More;\E\n\n};
     
     if ($basefn eq 'README') {
@@ -621,13 +621,13 @@ sub parse_file_start {
         );
 
         $self->parse(
-            qr/\A\s*configure_requires => \{\n *\Q'$self->{builder}' => '0'\E,\n\s*\},\n/ms,
+            qr/\A\s*configure_requires => \{\n *\Q'$self->{builder}' => '0.4004'\E,\n\s*\},\n/ms,
             "Configure Requires",
         );
 
         $self->parse(
-            qr/\A\s*build_requires => \{\n *\Q'Test::More' => '0'\E,\n\s*\},\n/ms,
-            "Build Requires",
+            qr/\A\s*test_requires => \{\n *\Q'Test::More' => '0'\E,\n\s*\},\n/ms,
+            "Test Requires",
         );
 
         $self->parse(
@@ -641,7 +641,7 @@ sub parse_file_start {
         );
     }
     elsif ($basefn eq 'Makefile.PL' && $self->{builder} eq 'ExtUtils::MakeMaker') {
-        plan tests => 11;
+        plan tests => 10;
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
         );
@@ -666,10 +666,6 @@ sub parse_file_start {
             "LICENSE",
         );
 
-        $self->parse(qr{\A\s*PL_FILES *=> *\{\},\n}ms,
-            "PL_FILES",
-        );
-
         $self->parse(qr{\A\s*MIN_PERL_VERSION *=> *\Q'$minperl',\E\n}ms,
             "MIN_PERL_VERSION",
         );
@@ -680,8 +676,8 @@ sub parse_file_start {
         );
 
         $self->parse(
-            qr/\A\s*BUILD_REQUIRES => \{\n *\Q'Test::More' => '0'\E,\n\s*\},\n/ms,
-            "BUILD_REQUIRES",
+            qr/\A\s*TEST_REQUIRES => \{\n *\Q'Test::More' => '0'\E,\n\s*\},\n/ms,
+            "TEST_REQUIRES",
         );
 
         $self->parse(
@@ -737,8 +733,8 @@ EOT
         );
 
         $self->parse(
-            qr/\A\s*build_requires \(\n *\Q'Test::More' => '0'\E,\n\s*\);\n/ms,
-            "build_requires",
+            qr/\A\s*test_requires \(\n *\Q'Test::More' => '0'\E,\n\s*\);\n/ms,
+            "test_requires",
         );
 
         $self->parse(


### PR DESCRIPTION
* EUMM Makefile.PL: several keys need compatibility boilerplate for older EUMM, and we should use TEST_REQUIRES for test requirements.
* MB Build.PL: use test_requires for test requirements and specify the required MB for this. (Without an EUMM fallback this is already broken on the CPAN.pm that comes with 5.8 anyway, so just specify the requirement for the versions where it will work)
* MI Makefile.PL: use test_requires. Assume the user will bundle a recent version of MI that supports this.