### PR TITLE
Always use the ustar format of tar

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -440,6 +440,7 @@ my %WriteMakefileArgs = (
         #'ABC'              => '1.6',
         #'Foo::Bar::Module' => '5.0401',
     },
+    macro => { TARFLAGS => '--format=ustar -c -v -f' },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => '$self->{distro}-*' },
 );


### PR DESCRIPTION
This should prevent the module from being uninstallable on systems
that don't support PAX headers, but the tar of the creator of the
distribution supports them.

See e.g. https://github.com/Dual-Life/Devel-PPPort/issues/183 or
https://huntingbears.nl/2015/02/17/new-tar-paxheaders-and-installing-from-cpan/