### PR TITLE
Add --github option with issue tracker in README, POD (replacing cpan…

### DIFF
--- a/lib/Module/Starter.pm
+++ b/lib/Module/Starter.pm
@@ -53,6 +53,7 @@ It takes a hash of params, as follows:
     license      => $license,  # type of license; defaults to 'artistic2'
     author       => $author,   # author's full name (taken from C<getpwuid> if not provided)
     email        => $email,    # author's email address (taken from C<EMAIL> if not provided)
+    github       => $username, # author's github user name (for creating links to git repo)
     ignores_type => $type,     # ignores file type ('generic', 'cvs', 'git', 'hg', 'manifest' )
     fatalize     => $fatalize, # generate code that makes warnings fatal
 
@@ -131,10 +132,6 @@ You can also look for information at:
 =item * Source code at GitHub
 
 L<https://github.com/xsawyerx/module-starter>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/dist/Module-Starter>
 
 =item * GitHub issue tracker
 

--- a/lib/Module/Starter/App.pm
+++ b/lib/Module/Starter/App.pm
@@ -81,6 +81,7 @@ sub _process_command_line {
 
         'author=s'   => \$config{author},
         'email=s'    => \$config{email},
+        'github=s'   => \$config{github},
         'license=s'  => \$config{license},
         genlicense   => \$config{genlicense},
         'minperl=s'  => \$config{minperl},

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -325,8 +325,9 @@ sub _reference_links {
         title    => 'CPAN\'s request tracker (report bugs here)',
         link     => 'https://rt.cpan.org/NoAuth/Bugs.html?Dist=%s',
       },
-      { title    => 'CPAN Ratings',
-        link     => 'https://cpanratings.perl.org/d/%s',
+      { title    => 'GitHub issue tracker',
+        link     => 'https://github.com/%s/%s/issues',
+        option   => 'github',
       },
       { title    => 'Search CPAN',
         link     => 'https://metacpan.org/release/%s',
@@ -409,6 +410,8 @@ sub Makefile_PL_guts {
 
     my $warnings = sprintf 'warnings%s;', ($self->{fatalize} ? " FATAL => 'all'" : '');
 
+    my $meta_merge = $self->Makefile_PL_meta_merge;
+
     return <<"HERE";
 use $self->{minperl};
 use strict;
@@ -434,7 +437,7 @@ my %WriteMakefileArgs = (
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => '$self->{distro}-*' },
-);
+$meta_merge);
 
 # Compatibility with old versions of ExtUtils::MakeMaker
 unless (eval { ExtUtils::MakeMaker->VERSION('6.64'); 1 }) {
@@ -457,6 +460,30 @@ delete \$WriteMakefileArgs{LICENSE}
 WriteMakefile(%WriteMakefileArgs);
 HERE
 
+}
+
+=head2 Makefile_PL_meta_merge
+
+Method called by Makefile_PL_guts. Returns the C<META_MERGE> section - currently
+only if the option C<github> is set, in which case the C<resources => repository>
+entry is created.
+
+=cut
+
+sub Makefile_PL_meta_merge {
+    my $self = shift;
+    return '' unless $self->{github};
+    return sprintf "    META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                type => 'git',
+                url  => 'git://github.com/%s/%s.git',
+                web  => 'https://github.com/%s/%s',
+            },
+        },
+    },
+", $self->{github}, $self->{distro}, $self->{github}, $self->{distro}
 }
 
 =head2 MI_Makefile_PL_guts( $main_module, $main_pm_file )
@@ -700,10 +727,12 @@ sub _README_information {
     my $content = "You can also look for information at:\n";
 
     foreach my $ref (@reference_links){
+        next if $ref->{option} && !$self->{$ref->{option}};
+
         my $title;
         $title = "$ref->{nickname}, " if exists $ref->{nickname};
         $title .= $ref->{title};
-        my $link  = sprintf($ref->{link}, $self->{distro});
+        my $link  = sprintf($ref->{link}, $ref->{option} ? $self->{$ref->{option}} : (), $self->{distro});
 
         $content .= qq[
     $title
@@ -1420,8 +1449,10 @@ You can also look for information at:
 ];
 
     foreach my $ref (@reference_links) {
+        next if $ref->{option} && !$self->{$ref->{option}};
+
         my $title;
-        my $link = sprintf($ref->{link}, $self->{distro});
+        my $link = sprintf($ref->{link}, $ref->{option} ? $self->{$ref->{option}} : (), $self->{distro});
 
         $title = "$ref->{nickname}: " if exists $ref->{nickname};
         $title .= $ref->{title};

--- a/t/data/templates/Module.pm
+++ b/t/data/templates/Module.pm
@@ -74,10 +74,6 @@ You can also look for information at:
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=Foo-Bar>
 
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/d/Foo-Bar>
-
 =item * Search CPAN
 
 L<https://metacpan.org/release/Foo-Bar>

--- a/t/data/templates/README
+++ b/t/data/templates/README
@@ -30,9 +30,6 @@ You can also look for information at:
     GitHub issue tracker
         https://github.com/xsawyerx/module-starter/issues
 
-    CPAN Ratings
-        http://cpanratings.perl.org/d/Foo-Bar
-
     Search CPAN
         https://metacpan.org/release/Foo-Bar
 

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -700,7 +700,7 @@ sub parse_module_start {
     my $lc_dist_name = lc($dist_name);
     my $minperl      = $self->{minperl} || 5.006;
     
-    Test::More::plan tests => 18;
+    Test::More::plan tests => 17;
 
     $self->parse(
         qr/\Apackage \Q$perl_name\E;\n\nuse $minperl;\nuse strict;\n\Quse warnings;\E\n\n/ms,
@@ -805,15 +805,6 @@ sub parse_module_start {
             "L<https://rt.cpan.org/NoAuth/Bugs.html?Dist=$dist_name>",
         ],
         "Support - RT",
-    );
-
-
-    $self->parse_paras(
-        [
-            { re => q/=item \* CPAN Ratings[^\n]*/, },
-            "L<https://cpanratings.perl.org/d/$dist_name>",
-        ],
-        "CPAN Ratings",
     );
 
     $self->parse_paras(


### PR DESCRIPTION
A simple `--github <username>` option was added, which creates links to the github issue tracker replacing the defunct cpanratings links in README and POD.

The option also creates a `META_MERGE` section in `Makefile.PL` with the repo links.

Test suite is adjusted to pass, however I did not add more testing as it seemed complex to do for the randomized `test-dist.t`, while `module-starter.t` is disabled.

The PR should be addressing #80 and  #81 .