### PR TITLE
Fix release 1.79 issues

### DIFF
--- a/bin/module-starter
+++ b/bin/module-starter
@@ -35,6 +35,7 @@ Options:
                      Format: Author Name <author_email@domain.tld>
                      This option can be supplied multiple times for projects 
                      that have multiple authors.
+    --github=login   Create links to the author's GitHub issue tracker
 
     --ignores=type   Ignore type files to include (repeatable)
     --license=type   License under which the module will be distributed
@@ -68,11 +69,11 @@ Available Ignore Types:
 Example:
 
     module-starter --module=Foo::Bar,Foo::Bat \
-        --author="Andy Lester" --email=andy@petdance.com
+        --author="Andy Lester <andy@petdance.com>"
 
     module-starter --module=Foo::Bar,Foo::Bat \
-        --author="Andy Lester <andy@petdance.com> \
-        --author="Sawyer X <sawyerx@cpan.org>
+        --author="Andy Lester <andy@petdance.com>" \
+        --author="Sawyer X <sawyerx@cpan.org>"
 
 =head1 DESCRIPTION
 
@@ -101,17 +102,13 @@ colons.  Values that take lists are just space separated. Note that the
 C<--ignores> command line parameter corresponds to the C<ignores_type>
 configuration file entry. A sample configuration file might read:
 
- author: Ricardo SIGNES
- email:  rjbs@cpan.org
+ author: Ricardo SIGNES <rjbs@cpan.org>
  ignores_type: git
  plugins: Module::Starter::Simple Module::Starter::Plugin::XYZ
  xyz_option: red green blue
 
 This format may become more elaborate in the future, but a file of this type
 should remain valid.
-
-Please note, as of right now the configuration file does *not* have support 
-for multiple authors.
 
 =cut
 

--- a/lib/Module/Starter.pm
+++ b/lib/Module/Starter.pm
@@ -19,7 +19,7 @@ Nothing in here is meant for public consumption.  Use L<module-starter>
 from the command line.
 
     module-starter --module=Foo::Bar,Foo::Bat \
-        --author="Andy Lester" --email=andy@petdance.com
+        --author="Andy Lester <andy@petdance.com>"
 
 =head1 DESCRIPTION
 
@@ -50,15 +50,17 @@ It takes a hash of params, as follows:
                                       # or specify more than one builder in an
                                       # arrayref
 
-    license      => $license,  # type of license; defaults to 'artistic2'
-    author       => $author,   # author's full name (taken from C<getpwuid> if not provided)
-    email        => $email,    # author's email address (taken from C<EMAIL> if not provided)
-    github       => $username, # author's github user name (for creating links to git repo)
-    ignores_type => $type,     # ignores file type ('generic', 'cvs', 'git', 'hg', 'manifest' )
-    fatalize     => $fatalize, # generate code that makes warnings fatal
+    license      => $license,    # type of license; defaults to 'artistic2'
+    author       => [ authors ], # author(s) name and email address
+                                 # (if not provided, name and email are taken from getpwuid and
+                                 # EMAIL respectively)
+                                 # format: Author Name <author-email@domain.tld>
+    github       => $username,   # author's GitHub user name (for creating links to issue tracker)
+    ignores_type => $type,       # ignores file type ('generic', 'cvs', 'git', 'hg', 'manifest')
+    fatalize     => $fatalize,   # generate code that makes warnings fatal
 
-    verbose      => $verbose,  # bool: print progress messages; defaults to 0
-    force        => $force     # bool: overwrite existing files; defaults to 0
+    verbose      => $verbose,    # bool: print progress messages; defaults to 0
+    force        => $force       # bool: overwrite existing files; defaults to 0
 
 The ignores_type is a new feature that allows one to create SCM-specific ignore files.
 These are the mappings:

--- a/t/test-author.t
+++ b/t/test-author.t
@@ -1,0 +1,169 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Module::Starter::App ();
+use Module::Starter::Simple;
+use File::Temp qw( tempdir );
+
+# Test if author strings from configuration file get split correctly.
+subtest 'Test author splits from config file' => sub {
+    subtest 'Valid author strings' => sub {
+        my %VALID = (
+            'single author' => {
+                author   => 'Andy Lester <andy@petdance.com>',
+                expected => [
+                    'Andy Lester <andy@petdance.com>',
+                ],
+            },
+            'multiple authors; space separated' => {
+                author   => 'Andy Lester <andy@petdance.com> Sawyer X <sawyerx@cpan.org>',
+                expected => [
+                    'Andy Lester <andy@petdance.com>',
+                    'Sawyer X <sawyerx@cpan.org>',
+                ],
+            },
+            'multiple authors; comma separated' => {
+                author   => 'Andy Lester <andy@petdance.com>, Sawyer X <sawyerx@cpan.org>',
+                expected => [
+                    'Andy Lester <andy@petdance.com>',
+                    'Sawyer X <sawyerx@cpan.org>',
+                ],
+            },
+            'multiple authors; whitespace separated' => {
+                author   => qq{Andy Lester\t<andy\@petdance.com>\t\tSawyer  X  <sawyerx\@cpan.org>\t},
+                expected => [
+                    qq{Andy Lester\t<andy\@petdance.com>},
+                    'Sawyer  X  <sawyerx@cpan.org>',
+                ],
+            },
+            'multiple authors; punctuation' => {
+                author   => q{Andy L. <andy@petdance.com> 'Sawyer X' <sawyerx@cpan.org>},
+                expected => [
+                    'Andy L. <andy@petdance.com>',
+                    q{'Sawyer X' <sawyerx@cpan.org>},
+                ],
+            },
+            'multiple authors; punctuation + whitespace + comma' => {
+                author   => qq{Andy-Lester'   <andy\@petdance.com>  ,\t" Sawyer X. " <sawyerx\@cpan.org>  },
+                expected => [
+                    q{Andy-Lester'   <andy@petdance.com>},
+                    q{" Sawyer X. " <sawyerx@cpan.org>},
+                ],
+            },
+        );
+
+        foreach my $name ( sort keys %VALID ) {
+            my %config = Module::Starter::App->_config_multi_process( author => $VALID{$name}->{author} );
+
+            is_deeply( $config{author}, $VALID{$name}->{expected}, "Split match ($name)" );
+        }
+    };
+
+    subtest 'Invalid author strings' => sub {
+        subtest 'Do not split' => sub {
+            my @INVALID = (
+                'Andy Lester andy@petdance.com Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester<andy@petdance.com> Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester <<andy@petdance.com> Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester <andy@petdance.com>> Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester <andy@petdance.com>Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester <andy@petdance.com Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester andy@petdance.com> Sawyer X <sawyerx@cpan.org>',
+                'Andy Lester <> Sawyer X <sawyerx@cpan.org>',
+            );
+
+            foreach my $author ( @INVALID ) {
+                my %config = Module::Starter::App->_config_multi_process( author => $author );
+
+                is_deeply( $config{author}, [ $author ], 'String match' );
+            }
+        };
+
+        subtest 'Split incorrectly' => sub {
+            my %INVALID = (
+                'Andy Lester <andy@petdance.com> Sawyer X sawyerx@cpan.org Dan Book <dbook@cpan.org' =>
+                    'Sawyer X sawyerx@cpan.org Dan Book <dbook@cpan.org',
+
+                'Andy Lester <andy@petdance.com> Sawyer X<sawyerx@cpan.org> Dan Book <dbook@cpan.org' =>
+                    'Sawyer X<sawyerx@cpan.org> Dan Book <dbook@cpan.org',
+
+                'Andy Lester <andy@petdance.com> Sawyer X <<sawyerx@cpan.org> Dan Book <dbook@cpan.org>' =>
+                    'Sawyer X <<sawyerx@cpan.org> Dan Book <dbook@cpan.org>',
+
+                'Andy Lester <andy@petdance.com> Sawyer X <sawyerx@cpan.org>> Dan Book <dbook@cpan.org>' =>
+                    'Sawyer X <sawyerx@cpan.org>> Dan Book <dbook@cpan.org>',
+
+                'Andy Lester <andy@petdance.com> Sawyer X <sawyerx@cpan.org>Dan Book <dbook@cpan.org' =>
+                    'Sawyer X <sawyerx@cpan.org>Dan Book <dbook@cpan.org',
+
+                'Andy Lester <andy@petdance.com> Sawyer X <sawyerx@cpan.org Dan Book <dbook@cpan.org' =>
+                    'Sawyer X <sawyerx@cpan.org Dan Book <dbook@cpan.org',
+
+                'Andy Lester <andy@petdance.com> Sawyer X sawyerx@cpan.org> Dan Book <dbook@cpan.org' =>
+                    'Sawyer X sawyerx@cpan.org> Dan Book <dbook@cpan.org',
+
+                'Andy Lester <andy@petdance.com> Sawyer X <> Dan Book <dbook@cpan.org' =>
+                    'Sawyer X <> Dan Book <dbook@cpan.org',
+            );
+
+            foreach my $author ( sort keys %INVALID ) {
+                my %config = Module::Starter::App->_config_multi_process( author => $author );
+
+                is_deeply( $config{author}, [ 'Andy Lester <andy@petdance.com>', $INVALID{$author} ], 'Split match' );
+            }
+        };
+    };
+};
+
+# Test validation of author strings.
+# Spec: 'Author Name <author-email@domain.tld>'
+#
+# NOTE:
+#   Do not test valid strings since the distro would be created at every iteration,
+#   which generates unnecessary IO/noise.
+subtest 'Test author string validation' => sub {
+    my @INVALID = (
+        '<>',
+
+        'Andy Lester',
+        'Andy Lester<andy@petdance.com>',
+        'Andy Lester <<andy@petdance.com>',
+        'Andy Lester <andy@petdance.com>>',
+        'Andy Lester <andy@petdance.com',
+        'Andy Lester andy@petdance.com>',
+        'Andy Lester <>',
+
+        'Andy Lester <andy@petdance.com> Sawyer X <sawyerx@cpan.org>',
+        'Andy Lester <andy@petdance.com Sawyer X <sawyerx@cpan.org>',
+        'Andy Lester andy@petdance.com> Sawyer X sawyerx@cpan.org>',
+        'Andy Lester <> Sawyer X <>',
+
+        'Andy Lester <andy@petdance.com> Sawyer X <sawyerx@cpan.org> Dan Book <dbook@cpan.org',
+    );
+
+    my $CROAK_MSG = q{author strings must be in the format: 'Author Name <author-email@domain.tld>'};
+
+    my $tempdir = tempdir( CLEANUP => 1 );
+
+    foreach my $author ( @INVALID ) {
+        my $ms = Module::Starter::Simple->new(
+            dir     => $tempdir,
+            modules => [ qw( Foo::Bar ) ],
+            author  => [ $author ],
+        );
+
+        my $err = do {
+            local $@;
+            eval { $ms->create_distro };
+            $@;
+        };
+
+        ok( $err, qq{Invalid author: '$author'} );
+        like( $err, qr/\A$CROAK_MSG/, 'Croak msg match' );
+    }
+};
+
+done_testing();

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -192,7 +192,8 @@ sub parse_file_start {
     
     my $license_class = "Software::License::$LICENSES->{ $self->{license} }";
     require_module $license_class;
-    my $license     = $license_class->new({ holder => $self->{author} });
+    my $author      = join ',', @{$self->{author}};
+    my $license     = $license_class->new({ holder => $author });
     my $slname      = $license->meta2_name;
     my $license_url = $license->url;
     my $license_text = $license->license;
@@ -842,7 +843,8 @@ sub parse_module_start {
 
     my $license_class = "Software::License::$LICENSES->{ $self->{license} }";
     require_module $license_class;
-    my $license = $license_class->new({ holder => $self->{author} });
+    my $author  = join ',', @{$self->{author}};
+    my $license = $license_class->new({ holder => $author });
     my $license_blurb = $license->notice;
     $self->parse_paras(
         [


### PR DESCRIPTION
This PR resolves issues introduced by https://github.com/xsawyerx/module-starter/pull/90 and extends https://github.com/xsawyerx/module-starter/pull/88.

### Rationale

Configuration file does not support multiple authors and warns with `Can't use string as an ARRAY ref while "strict refs" in use ...` when an author is set. This forces authors to use _--author_ in command-line.

In `_license_record()`, the holder value is passed to `Software::License->new` without joining the array, causing generated files (README, lib/*.pm) to receive an ARRAY reference instead of an author string.

The `github` option is missing the `bugtracker` field and Module::Build support.
