### PR TITLE
Fix compilation on 5.12 and earlier

### DIFF
--- a/lib/Module/Starter/App.pm
+++ b/lib/Module/Starter/App.pm
@@ -60,24 +60,26 @@ sub _config_multi_process {
 
             # Split author strings on whitespace or comma.
             # Spec: 'Author Name <author-email@domain.tld>'
-            $config{$key} = [
-                split /
-                    \b
-                    (?>
+            my @authors;
+            while ($config{$key} =~ s/
+                    ^\s*
+                    ((?>
                         (?:           # Author
                             [^\s<>]+
                             \s+
                         )+
                     )
-                    <[^<>]+>          # Email
-                    \K
+                    <[^<>]+>)         # Email
                     (?:               # Separators (or end of string)
                         \s*,\s*
                         | \s+
                         | \z
                     )
-                /x, $config{$key}
-            ];
+                //x) {
+                push @authors, $1;
+            }
+            push @authors, $config{$key} if length $config{$key};
+            $config{$key} = \@authors;
         }
         else {
             $config{$key} = [ split /(?:\s*,\s*|\s+)/, (ref $config{$key} ? join(',', @{$config{$key}}) : $config{$key}) ] if $config{$key};

--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -418,7 +418,7 @@ sub Makefile_PL_guts {
     my $main_pm_file = shift;
 
     my $author = '[' . 
-       join(',', map { "'" . s/'/\'/rg . "'" } @{$self->{author}}) 
+       join(',', map { (my $x = $_) =~ s/'/\'/g; "'$x'" } @{$self->{author}}) 
        . ']';
     
     my $slname = $self->{license_record} ? $self->{license_record}->meta2_name : $self->{license};
@@ -619,7 +619,7 @@ sub Build_PL_guts {
     my $main_pm_file = shift;
 
     my $author = '[' . 
-       join(',', map { "'" . s/'/\'/rg . "'" } @{$self->{author}}) 
+       join(',', map { (my $x = $_) =~ s/'/\'/g;  "'$x'" } @{$self->{author}}) 
        . ']';
 
     my $slname = $self->{license_record} ? $self->{license_record}->meta2_name : $self->{license};


### PR DESCRIPTION
`s///r` requires 5.14, use a simple assignment instead

`\K` requires 5.10, which we could just bump the minimum to (Software::License requires 5.12 already so it's a matter of time), but its use in split is very confusing to me so this seems more straightforward anyway.