### PR TITLE
Fix single quotes escaped incorrectly

### DIFF
--- a/lib/Module/Starter/Simple.pm
+++ b/lib/Module/Starter/Simple.pm
@@ -418,7 +418,7 @@ sub Makefile_PL_guts {
     my $main_pm_file = shift;
 
     my $author = '[' . 
-       join(',', map { (my $x = $_) =~ s/'/\'/g; "'$x'" } @{$self->{author}}) 
+       join(',', map { (my $x = $_) =~ s/'/\\'/g; "'$x'" } @{$self->{author}}) 
        . ']';
     
     my $slname = $self->{license_record} ? $self->{license_record}->meta2_name : $self->{license};
@@ -522,8 +522,7 @@ sub MI_Makefile_PL_guts {
     my $main_module = shift;
     my $main_pm_file = shift;
 
-    my $author = join ',', @{$self->{author}};
-    $author =~ s/'/\'/g;
+    my $author = join(',', map { (my $x = $_) =~ s/'/\\'/g; "'$x'" } @{$self->{author}});
 
     my $license_url = $self->{license_record} ? $self->{license_record}->url : '';
 
@@ -540,8 +539,8 @@ use $warnings
 use inc::Module::Install;
 
 name     '$self->{distro}';
+author   $author;
 all_from '$main_pm_file';
-author   q{$author};
 license  '$self->{license}';
 
 perl_version '$self->{minperl}';
@@ -619,7 +618,7 @@ sub Build_PL_guts {
     my $main_pm_file = shift;
 
     my $author = '[' . 
-       join(',', map { (my $x = $_) =~ s/'/\'/g;  "'$x'" } @{$self->{author}}) 
+       join(',', map { (my $x = $_) =~ s/'/\\'/g;  "'$x'" } @{$self->{author}}) 
        . ']';
 
     my $slname = $self->{license_record} ? $self->{license_record}->meta2_name : $self->{license};

--- a/t/test-dist.t
+++ b/t/test-dist.t
@@ -250,8 +250,7 @@ sub parse_file_start {
     }
     elsif ($basefn eq 'Build.PL' && $self->{builder} eq 'Module::Build') {
         plan tests => 10;
-        my $authoremail = join ',', map { "'$_'" } @{$self->{author}};
-        $authoremail =~ s/'/\'/g;
+        my $authoremail = join(',', map { (my $x = $_) =~ s/'/\\'/g; "'$x'" } @{$self->{author}});
         
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
@@ -299,8 +298,7 @@ sub parse_file_start {
     }
     elsif ($basefn eq 'Makefile.PL' && $self->{builder} eq 'ExtUtils::MakeMaker') {
         plan tests => 10;
-        my $authoremail = join ',', map { "'$_'" } @{$self->{author}};
-        $authoremail =~ s/'/\'/g;
+        my $authoremail = join(',', map { (my $x = $_) =~ s/'/\\'/g; "'$x'" } @{$self->{author}});
         
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
@@ -349,8 +347,7 @@ sub parse_file_start {
        plan tests => 13;
        # do not quote authoremail combinations for Module::Install since
        # author is a string not an arrayref
-       my $authoremail = join ',', @{$self->{author}};
-       $authoremail =~ s/'/\'/g;
+       my $authoremail = join(',', map { (my $x = $_) =~ s/'/\\'/g; "'$x'" } @{$self->{author}});
        
         $self->parse($mswb_re,
             "Min/Strict/Warning/Builder"
@@ -360,12 +357,12 @@ sub parse_file_start {
             "name",
         );
 
-        $self->parse(qr{\Aall_from\s+\Q'$libmod';\E\n}ms,
-            "all_from",
+        $self->parse(qr{\Aauthor\s+\Q$authoremail;\E\n}ms,
+            "author",
         );
 
-        $self->parse(qr{\Aauthor\s+\Qq{$authoremail};\E\n}ms,
-            "author",
+        $self->parse(qr{\Aall_from\s+\Q'$libmod';\E\n}ms,
+            "all_from",
         );
 
         $self->parse(qr{\Alicense\s+\Q'$self->{license}';\E\n\n}ms,


### PR DESCRIPTION
If the author string contains a single quote, perl will die with a bareword syntax error when processing the generated Makefile.PL and Build.PL files.

`MI_Makefile_PL_guts()` joins authors in a single string and duplicates authors in META.yml.

I added a test for it, but not sure if it's needed or if I did it right